### PR TITLE
Updated OnProviderStateChanged method

### DIFF
--- a/CommunityToolkit.Authentication/ProviderManager.cs
+++ b/CommunityToolkit.Authentication/ProviderManager.cs
@@ -88,7 +88,7 @@ namespace CommunityToolkit.Authentication
 
         private void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs args)
         {
-            ProviderStateChanged?.Invoke(sender, args);
+            ProviderStateChanged?.Invoke(this, args);
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
         }
     }


### PR DESCRIPTION
Fixes #

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This is a one word change:

```
// OLD
private void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs args)
{
    ProviderStateChanged?.Invoke(sender, args); // <- 'sender' is wrong
    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
}

// NEW
private void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs args)
{
    ProviderStateChanged?.Invoke(this, args); <- Need to use 'this' instead
    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
}
```

This is inspired by a recent bugfix in main.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
