### PR TITLE
Updated how Graph service exceptions are handling in controls

### DIFF
--- a/CommunityToolkit.Graph.Uwp/Controls/PeoplePicker/PeoplePicker.cs
+++ b/CommunityToolkit.Graph.Uwp/Controls/PeoplePicker/PeoplePicker.cs
@@ -105,14 +105,25 @@ namespace CommunityToolkit.Graph.Uwp.Controls
             IGraphServiceUsersCollectionPage usersCollection = null;
             try
             {
+                // Returns an empty collection if no results found.
                 usersCollection = await graph.FindUserAsync(text);
             }
-            catch
+            catch (Microsoft.Graph.ServiceException e)
             {
-                // No users found.
+                if (e.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                {
+                    // Insufficient privileges.
+                    // Incremental consent must not be supported by the current provider.
+                    // TODO: Log or handle the lack of sufficient privileges.
+                }
+                else
+                {
+                    // Something unexpected happened.
+                    throw;
+                }
             }
 
-            if (usersCollection != null)
+            if (usersCollection != null && usersCollection.Count > 0)
             {
                 foreach (var user in usersCollection.CurrentPage)
                 {
@@ -127,14 +138,25 @@ namespace CommunityToolkit.Graph.Uwp.Controls
             IUserPeopleCollectionPage peopleCollection = null;
             try
             {
+                // Returns an empty collection if no results found.
                 peopleCollection = await graph.FindPersonAsync(text);
             }
-            catch
+            catch (Microsoft.Graph.ServiceException e)
             {
-                // No people found.
+                if (e.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                {
+                    // Insufficient privileges.
+                    // Incremental consent must not be supported by the current provider.
+                    // TODO: Log or handle the lack of sufficient privileges.
+                }
+                else
+                {
+                    // Something unexpected happened.
+                    throw;
+                }
             }
 
-            if (peopleCollection != null)
+            if (peopleCollection != null && peopleCollection.Count > 0)
             {
                 // Grab ids of current suggestions
                 var ids = list.Cast<object>().Select(person => (person as Person).Id);

--- a/CommunityToolkit.Graph/Extensions/GraphExtensions.People.cs
+++ b/CommunityToolkit.Graph/Extensions/GraphExtensions.People.cs
@@ -20,21 +20,13 @@ namespace CommunityToolkit.Graph.Extensions
         /// <returns><see cref="IUserPeopleCollectionPage"/> collection of <see cref="Person"/>.</returns>
         public static async Task<IUserPeopleCollectionPage> FindPersonAsync(this GraphServiceClient graph, string query)
         {
-            try
-            {
-                return await graph
-                    .Me
-                    .People
-                    .Request()
-                    .Search(query)
-                    ////.WithScopes(new string[] { "people.read" })
-                    .GetAsync();
-            }
-            catch
-            {
-            }
-
-            return new UserPeopleCollectionPage();
+            return await graph
+                .Me
+                .People
+                .Request()
+                .Search(query)
+                .WithScopes(new string[] { "people.read" })
+                .GetAsync();
         }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes)-->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

When the `GraphServiceClient` fails to make a request for whatever reason and throws an exception, in most cases we eat the exception and move on. This makes it difficult to understand WHY a request has failed and whether the exception encountered is part of normal logical flow (e.g. 404 - Not Found), or actually unexpected.

## What is the new behavior?

In the new behavior, Graph client extension methods no longer eat exceptions, so any `GraphServiceClient` exceptions will bubble up to the caller.

The controls have also been updated to handle any expected exceptions that may occur when using the `GraphServiceClient` to make requests, and rethrow any unexpected ones. This increases stability for controls like `PersonView`, which is frequently used to represent entities that do not support a profile photo, such as conference rooms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I also tested the `WithScopes` method to see if issue #8 still exists, and it appears that incremental consent is not working at the moment. Perhaps there is some additional configuration required in MsalProvider to get it going, but I'm not sure what that is. WindowsProvider is based on WAM apis that do not support incremental consent quite yet, so it is not expected to work there.

So the current behavior is that `WithScopes` seemingly does nothing. It doesn't show a prompt for additional consent, and will throw a 403 when calling for resources without the pre-requisite consent. 

Based on this, we should investigate how incremental consent is expected to work with MSAL for .NET and see if we can get that working.