### PR TITLE
Fixes #149 - Update Sample to use External ObservableCollection

### DIFF
--- a/SampleTest/Samples/PeoplePickerSample.xaml
+++ b/SampleTest/Samples/PeoplePickerSample.xaml
@@ -1,29 +1,32 @@
-﻿<Page
-    x:Class="SampleTest.Samples.PeoplePickerSample"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:SampleTest.Samples"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls"
-    xmlns:graph="using:Microsoft.Graph"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+﻿<Page x:Class="SampleTest.Samples.PeoplePickerSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:graph="using:Microsoft.Graph"
+      xmlns:local="using:SampleTest.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
 
     <Page.Resources>
         <graph:Person x:Key="GraphPerson" />
     </Page.Resources>
-    
+
     <Grid>
         <StackPanel>
-            <TextBlock Margin="0,0,0,16" TextWrapping="WrapWholeWords">
+            <TextBlock Margin="0,0,0,16"
+                       TextWrapping="WrapWholeWords">
                 The `PeoplePicker` lets a logged in user easily search for familiar people they interact with or contacts. Great for emails or messages.
             </TextBlock>
-            <controls:PeoplePicker x:Name="PeopleChooser" />
-            <TextBlock Margin="0,8,0,0" FontWeight="Bold">
+            <controls:PeoplePicker x:Name="PeopleChooser"
+                                   ItemsSource="{x:Bind MyPeople}" />
+            <TextBlock Margin="0,8,0,0"
+                       FontWeight="Bold">
                 Picked People:
             </TextBlock>
-            <ItemsControl Margin="8,0,0,0" ItemsSource="{x:Bind PeopleChooser.ItemsSource}">
+            <ItemsControl Margin="8,0,0,0"
+                          ItemsSource="{x:Bind MyPeople}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="graph:Person">
                         <TextBlock Text="{x:Bind DisplayName}" />

--- a/SampleTest/Samples/PeoplePickerSample.xaml.cs
+++ b/SampleTest/Samples/PeoplePickerSample.xaml.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.ObjectModel;
+using Microsoft.Graph;
 using Windows.UI.Xaml.Controls;
 
 namespace SampleTest.Samples
 {
     public sealed partial class PeoplePickerSample : Page
     {
+        ObservableCollection<Person> MyPeople { get; set; } = new();
+
         public PeoplePickerSample()
         {
             InitializeComponent();


### PR DESCRIPTION
Fixes #149

We re-write the sample to use an external collection as a developer would in their app. This then properly lets the ItemsControl display just the tokenized items. (Though there's still an issue with how TokenizingTextBox behaves we should resolve.)

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Sample app changes
<!-- - Other... Please describe: -->

## What is the current behavior?

Trying to point to the ItemsSource of the TokenizingTextBox gives us the wrong collection.

## What is the new behavior?

We use an external collection (as a developer would bind to their data model) and use that to bind to both the TTB and the ItemsControl. Then it works as intended.

Will open an issue on the main repo for tracking a fix to the underlying TTB.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
