### PR TITLE
Added logging to auth providers

### DIFF
--- a/CommunityToolkit.Authentication.Msal/MsalProvider.cs
+++ b/CommunityToolkit.Authentication.Msal/MsalProvider.cs
@@ -80,9 +80,10 @@ namespace CommunityToolkit.Authentication
         /// <param name="autoSignIn">Determines whether the provider attempts to silently log in upon creation.</param>
         /// <param name="listWindowsWorkAndSchoolAccounts">Determines if organizational accounts should be enabled/disabled.</param>
         /// <param name="tenantId">Registered tenant id in Azure Active Directory.</param>
-        public MsalProvider(string clientId, string[] scopes = null, string redirectUri = null, bool autoSignIn = true, bool listWindowsWorkAndSchoolAccounts = true, string tenantId = null)
+        /// <param name="withLogging">Output logs.</param>
+        public MsalProvider(string clientId, string[] scopes = null, string redirectUri = null, bool autoSignIn = true, bool listWindowsWorkAndSchoolAccounts = true, string tenantId = null, bool withLogging = false)
         {
-            Client = CreatePublicClientApplication(clientId, tenantId, redirectUri, listWindowsWorkAndSchoolAccounts);
+            Client = CreatePublicClientApplication(clientId, tenantId, redirectUri, listWindowsWorkAndSchoolAccounts, withLogging);
             Scopes = scopes.Select(s => s.ToLower()).ToArray() ?? new string[] { string.Empty };
 
             if (autoSignIn)
@@ -183,8 +184,9 @@ namespace CommunityToolkit.Authentication
         /// <param name="tenantId">An optional tenant id.</param>
         /// <param name="redirectUri">Redirect uri for auth response.</param>
         /// <param name="listWindowsWorkAndSchoolAccounts">Determines if organizational accounts should be supported.</param>
+        /// <param name="withLogging">Output logs.</param>
         /// <returns>A new instance of <see cref="PublicClientApplication"/>.</returns>
-        protected IPublicClientApplication CreatePublicClientApplication(string clientId, string tenantId, string redirectUri, bool listWindowsWorkAndSchoolAccounts)
+        protected IPublicClientApplication CreatePublicClientApplication(string clientId, string tenantId, string redirectUri, bool listWindowsWorkAndSchoolAccounts, bool withLogging)
         {
             var authority = listWindowsWorkAndSchoolAccounts ? AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount : AadAuthorityAudience.PersonalMicrosoftAccount;
 
@@ -192,6 +194,20 @@ namespace CommunityToolkit.Authentication
                 .WithAuthority(AzureCloudInstance.AzurePublic, authority)
                 .WithClientName(ProviderManager.ClientName)
                 .WithClientVersion(Assembly.GetExecutingAssembly().GetName().Version.ToString());
+
+            if (withLogging)
+            {
+                clientBuilder = clientBuilder.WithLogging((level, message, containsPii) =>
+                {
+                    if (containsPii)
+                    {
+                        // Add a PII warning to messages containing any.
+                        message = $"[CONTAINS PII] {message}";
+                    }
+
+                    EventLogger.Log($"{level}: {message}");
+                });
+            }
 
             if (tenantId != null)
             {
@@ -232,13 +248,15 @@ namespace CommunityToolkit.Authentication
                         authResult = await Client.AcquireTokenSilent(scopes, account).ExecuteAsync();
                     }
                 }
-                catch (MsalUiRequiredException)
+                catch (MsalUiRequiredException e)
                 {
+                    EventLogger.Log(e.Message);
                 }
-                catch
+                catch (Exception e)
                 {
                     // Unexpected exception
-                    // TODO: Send exception to a logger.
+                    EventLogger.Log(e.Message);
+                    EventLogger.Log(e.StackTrace);
                 }
 
                 if (authResult == null && !silentOnly)
@@ -266,10 +284,11 @@ namespace CommunityToolkit.Authentication
 
                         authResult = await paramBuilder.ExecuteAsync();
                     }
-                    catch
+                    catch (Exception e)
                     {
                         // Unexpected exception
-                        // TODO: Send exception to a logger.
+                        EventLogger.Log(e.Message);
+                        EventLogger.Log(e.StackTrace);
                     }
                 }
 

--- a/CommunityToolkit.Authentication/BaseProvider.cs
+++ b/CommunityToolkit.Authentication/BaseProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using CommunityToolkit.Authentication.Extensions;
+using CommunityToolkit.Authentication.Logging;
 
 namespace CommunityToolkit.Authentication
 {
@@ -33,6 +34,11 @@ namespace CommunityToolkit.Authentication
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the logger used to log exceptions and event messages.
+        /// </summary>
+        public ILogger EventLogger { get; set; } = DebugLogger.Instance;
 
         /// <inheritdoc />
         public abstract string CurrentAccountId { get; }

--- a/CommunityToolkit.Authentication/Logging/DebugLogger.cs
+++ b/CommunityToolkit.Authentication/Logging/DebugLogger.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace CommunityToolkit.Authentication.Logging
+{
+    /// <summary>
+    /// Logs messages using the <see cref="Debug"/> API.
+    /// </summary>
+    public class DebugLogger : ILogger
+    {
+        /// <summary>
+        /// Singleton instance.
+        /// </summary>
+        public static readonly DebugLogger Instance = new DebugLogger();
+
+        /// <inheritdoc />
+        public void Log(string message)
+        {
+            Debug.WriteLine(message);
+        }
+    }
+}

--- a/CommunityToolkit.Authentication/Logging/ILogger.cs
+++ b/CommunityToolkit.Authentication/Logging/ILogger.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CommunityToolkit.Authentication.Logging
+{
+    /// <summary>
+    /// Defines a simple logger for handling messages during runtime.
+    /// </summary>
+    public interface ILogger
+    {
+        /// <summary>
+        /// Log a message.
+        /// </summary>
+        /// <param name="message">The message to log.</param>
+        void Log(string message);
+    }
+}


### PR DESCRIPTION
Fixes #179

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the logging in the auth providers is rather unhelpful when troubleshooting authentication configuration issues. In various cases exceptions are eaten which is particularly unhelpful. 

## What is the new behavior?

There are a few parts to the logging issue:

### 1. The logger interface and implementation

The `ILogger` represents a *very* basic logger that I think needs some representation in the toolkit. However, I don't think that the authentication packages are necessarily the correct place for this. Instead, I'd like to see the `ILogger` interface put in the `CommunityToolkit.Diagnostics` package ([link](https://github.com/CommunityToolkit/dotnet/tree/main/CommunityToolkit.Diagnostics)). This enables us to offer the simple `DebugLogger` based on `System.Diagnostics.Debug.WriteLine`

### 2. Consuming the logger

I'm a bit torn in my decision on how to consumer the logger. The easy way I think is to just create a new instance of `DebugLogger` and start logging messages, but that defeats the purpose of offering an interface to begin with. There needs to be somewhere to maintain the global `ILogger` instance so that all toolkit components can access it from anywhere:

I made the logger a member of `BaseProvider`, but in hindsight I wish it were in its own class. Something like a singleton `LogManager` with a getter/setter for `LogManager.Logger` which is an `ILogger` based implementation. As a note, this would require developers with a custom logger of their own to extend `ILogger` OR use a shim class instead to connect it to the LogManager:

```csharp
// Manages the global logger instance
public class LogManager
{
    public bool IsLoggingEnabled { get; set; } = false;

    public ILogger Logger { get; set; } = new DebugLogger();
}

// An example custom logger, if you don't want the default DebugLogger
public class CustomLogger : ILogger
{
    public void Log(string message)
    {
        // Call your custom logger here
    }
}

// Set somewhere in app startup code
LogManager.IsLoggingEnabled = true;
LogManager.Logger = new CustomLogger();
```

### 3. Applying the logger to WindowsProvider

Pretty straight forward, ensure that every try/catch block sends any exceptions to the logger. Also look for opportunities to log other common events that could help with troubleshooting.

### 4. Applying the logger to MsalProvider

First ensure that every try/catch block sends any exceptions to the logger. But also, the `MsalProvider` leverages the `PublicClientApplication` object from MSAL for .NET which has a mechanism for passing in a method to handle the log output. This is enabled by using the `WithLogging` method on the client builder. This can be connected with the LogManager like so:

`clientBuilder.WithLogging((level, message, containsPii) => LogManager.Logger.Log(message));`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
This is a DRAFT, so some of the concepts described are not accurate to the actual code changes I made so far. More discussion needs to happen on where is the correct place for the logger to live. Is it the *Diagnostics* package or perhaps *Common*? Please continue this in the issue #179