### PR TITLE
Add Optional Scopes Param to WindowsProvider GetTokenAsync

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -184,16 +184,17 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc />
-        public override async Task<string> GetTokenAsync(bool silentOnly = false)
+        public override async Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
         {
             await SemaphoreSlim.WaitAsync();
 
             try
             {
-                var scopes = _scopes;
+                // use request specific scopes if not null, otherwise use class scopes
+                var authenticationScopes = scopes ?? this._scopes;
 
                 // Attempt to authenticate silently.
-                var authResult = await AuthenticateSilentAsync(scopes);
+                var authResult = await AuthenticateSilentAsync(authenticationScopes);
 
                 // Authenticate with user interaction as appropriate.
                 if (authResult?.ResponseStatus != WebTokenRequestStatus.Success)

--- a/CommunityToolkit.Authentication/BaseProvider.cs
+++ b/CommunityToolkit.Authentication/BaseProvider.cs
@@ -52,7 +52,7 @@ namespace CommunityToolkit.Authentication
         public abstract Task AuthenticateRequestAsync(HttpRequestMessage request);
 
         /// <inheritdoc />
-        public abstract Task<string> GetTokenAsync(bool silentOnly = false);
+        public abstract Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
 
         /// <inheritdoc />
         public abstract Task SignInAsync();

--- a/CommunityToolkit.Authentication/IProvider.cs
+++ b/CommunityToolkit.Authentication/IProvider.cs
@@ -39,8 +39,9 @@ namespace CommunityToolkit.Authentication
         /// Retrieve a token for the authenticated user.
         /// </summary>
         /// <param name="silentOnly">Determines if the acquisition should be done without prompts to the user.</param>
+        /// <param name="scopes"> Optional param for setting scopes specific to this token request </param>
         /// <returns>A token string for the authenticated user.</returns>
-        Task<string> GetTokenAsync(bool silentOnly = false);
+        Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
 
         /// <summary>
         /// Sign in the user.

--- a/CommunityToolkit.Authentication/MockProvider.cs
+++ b/CommunityToolkit.Authentication/MockProvider.cs
@@ -52,7 +52,7 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc/>
-        public override Task<string> GetTokenAsync(bool silentOnly = false)
+        public override Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
         {
             return Task.FromResult("<mock-provider-token>");
         }


### PR DESCRIPTION
Fixes #

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

GetTokenAsync always uses scopes set in WindowsProvider constructor.

## What is the new behavior?
GetTokenAsync has an optional param to use different scopes for the token request. Behavior remains the same if not provided.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Documentation for WindowsProvider already shows this arg, so looks like it was intended but never implemented.