### PR TITLE
Avoid adding empty providers

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -33,7 +33,7 @@ namespace CommunityToolkit.Authentication
         private const string SettingsKeyProviderId = "WindowsProvider_ProviderId";
         private const string SettingsKeyProviderAuthority = "WindowsProvider_Authority";
 
-        private static readonly SemaphoreSlim SemaphoreSlim = new(1);
+        private static readonly SemaphoreSlim SemaphoreSlim = new (1);
 
         // Default/minimal scopes for authentication, if none are provided.
         private static readonly string[] DefaultScopes = { "User.Read" };

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -33,7 +33,7 @@ namespace CommunityToolkit.Authentication
         private const string SettingsKeyProviderId = "WindowsProvider_ProviderId";
         private const string SettingsKeyProviderAuthority = "WindowsProvider_Authority";
 
-        private static readonly SemaphoreSlim SemaphoreSlim = new (1);
+        private static readonly SemaphoreSlim SemaphoreSlim = new(1);
 
         // Default/minimal scopes for authentication, if none are provided.
         private static readonly string[] DefaultScopes = { "User.Read" };
@@ -562,24 +562,37 @@ namespace CommunityToolkit.Authentication
             if (_webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Any ||
                 _webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Msa)
             {
-                providers.Add(await WebAuthenticationCoreManager.FindAccountProviderAsync(MicrosoftProviderId, MicrosoftAccountAuthority));
+                await FindAndAddProviderAsync(MicrosoftProviderId, MicrosoftAccountAuthority);
             }
 
             // AAD
             if (_webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Any ||
                 _webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Aad)
             {
-                providers.Add(await WebAuthenticationCoreManager.FindAccountProviderAsync(MicrosoftProviderId, AadAuthority));
+                await FindAndAddProviderAsync(MicrosoftProviderId, AadAuthority);
             }
 
             // Local
             if (_webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Any ||
                 _webAccountProviderConfig.WebAccountProviderType == WebAccountProviderType.Local)
             {
-                providers.Add(await WebAuthenticationCoreManager.FindAccountProviderAsync(LocalProviderId));
+                await FindAndAddProviderAsync(LocalProviderId);
             }
 
             return providers;
+
+            async Task FindAndAddProviderAsync(
+                string webAccountProviderId,
+                string authority = default)
+            {
+                var provider = string.IsNullOrEmpty(authority)
+                    ? await WebAuthenticationCoreManager.FindAccountProviderAsync(webAccountProviderId)
+                    : await WebAuthenticationCoreManager.FindAccountProviderAsync(webAccountProviderId, authority);
+                if (provider != null)
+                {
+                    providers.Add(provider);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #190 

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

When adding a `WebAccountProvider`, there is no **null** judgment on the acquired provider, resulting in a null reference in the provider added to the list, which directly causes an unexpected provider (null) to be passed in when the `WebAccountProviderCommand` is created, causing the process to be interrupted and unable to log in.

## What is the new behavior?

Create a new method and add it to the list only when the obtained `WebAccountProvider` is not null.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
